### PR TITLE
Ensure same classnames are generated with css-modulesify

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,13 @@ var interpolateName = require('loader-utils').interpolateName;
 var path = require('path');
 var util = require('util');
 
+function relativePathTo(root, path) {
+  if(path.indexOf(root) == 0) {
+    path = path.slice(root.length);
+  }
+  return path;
+}
+
 /**
  * @param  {string} pattern
  * @param  {object} options
@@ -30,10 +37,11 @@ module.exports = function createGenerator(pattern, options) {
     var loaderContext = {
       resourcePath: filepath
     };
+
     var loaderOptions = {
       content: util.format('%s%s+%s',
         hashPrefix,
-        path.relative(context, filepath),
+        relativePathTo(context, filepath),
         localName),
       context: context
     };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generic-names",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Helper for building generic names, similar to webpack",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
A bit of a disclaimer: I didn't deep dive into this.
I was seeing different classnames generated despite passing the same function to [css-modulesify](https://github.com/css-modules/css-modulesify) and [babel-plugin-css-modules](https://github.com/michalkvasnicak/babel-plugin-css-modules-transform) for my universal project. Found out using path.relative was creating relative paths like '../../../../src/components/...' so I've replaced path.relative with a simple slice as css-modulesify do.
