### PR TITLE
fix(generate): Replace `+` with `\x00`

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ module.exports = function createGenerator(pattern, options) {
       content:
         hashPrefix +
         path.relative(context, filepath).replace(/\\/g, "/") +
-        "+" +
+        "\x00" +
         localName,
       context: context
     };

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,9 @@
       "dev": true
     },
     "big.js": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -53,9 +53,9 @@
       "dev": true
     },
     "emojis-list": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q=="
     },
     "es-abstract": {
       "version": "1.12.0",
@@ -169,18 +169,28 @@
       "dev": true
     },
     "json5": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+      "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+      "requires": {
+        "minimist": "^1.2.5"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+        }
+      }
     },
     "loader-utils": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
-      "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+      "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
       "requires": {
-        "big.js": "^3.1.3",
-        "emojis-list": "^2.0.0",
-        "json5": "^0.5.0"
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^2.1.2"
       }
     },
     "minimatch": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "tape": "^4.6.2"
   },
   "dependencies": {
-    "loader-utils": "^1.1.0"
+    "loader-utils": "^2.0.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -11,7 +11,7 @@ test("use `cwd` if no context was provided", t => {
 
   t.equal(
     generate("foo", path.join(__dirname, "test/case/source.css")),
-    "source__foo___3D34a"
+    "source__foo___2e6d7"
   );
   t.end();
 });
@@ -23,7 +23,7 @@ test("generate distinct hash for the provided context", t => {
 
   t.equal(
     generate("foo", path.join(__dirname, "test/case/source.css")),
-    "source__foo___19xFw"
+    "source__foo___22-0m"
   );
   t.end();
 });
@@ -36,7 +36,7 @@ test("generate distinct hash for the provided hashPrefix", t => {
 
   t.equal(
     generate("foo", path.join(__dirname, "test/case/source.css")),
-    "source__foo___3T0Un"
+    "source__foo___1rt0M"
   );
   t.end();
 });


### PR DESCRIPTION
## Problem

[This PR](https://github.com/webpack-contrib/css-loader/pull/1121/files#diff-3274f1a37032fb0ae4e2823def0007c634e869ae0dfc304ff6a12c36513c3a52R64) changed the `content` being passed to `interpolateName` (in `loader-utils`) from including a plus `+` to including `\x00`. This is now in `css-loader` >= 4. However, `generic-names` still using `+` so there's now an inconsistency in how the class names are generated.

Given that this library is basically piggybacking on what webpack does, it should be updated to match.

This caused `babel-plugin-react-css-modules` to break: https://github.com/gajus/babel-plugin-react-css-modules/issues/291

## Solution

Use `\x00` instead of `+` and update the tests.

Fixes #8.

BREAKING CHANGE: This change will result in new names being generated, particularly those using `[hash]`. You will need to upgrade to `css-loader` >= 4 if you are wanting to keep the classes in sync.