### PR TITLE
feat: implement regExp option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,7 @@
 interface Options {
   context: string;
   hashPrefix: string;
+  regExp?: RegExp;
 }
 
 type Generator = (localName: string, filepath: string) => string;

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ var path = require("path");
  * @param  {object} options
  * @param  {string} options.context
  * @param  {string} options.hashPrefix
+ * @param  {RegExp} options.regExp
  * @return {function}
  */
 module.exports = function createGenerator(pattern, options) {
@@ -37,6 +38,7 @@ module.exports = function createGenerator(pattern, options) {
         "\x00" +
         localName,
       context: context,
+      regExp: options.regExp,
     };
 
     var genericName = interpolateName(loaderContext, name, loaderOptions);

--- a/test/index.js
+++ b/test/index.js
@@ -40,3 +40,13 @@ test("generate distinct hash for the provided hashPrefix", t => {
   );
   t.end();
 });
+
+test("use group matches if regExp was provided", t => {
+  const generate = genericNames('[1]__[2]', { regExp: /([^/]*)\/([^/]*)$/ })
+
+  t.equal(
+    generate("foo", path.join(__dirname, "test/case/source.css")),
+    "case__source-css"
+  );
+  t.end()
+})


### PR DESCRIPTION
this PR adds a `regExp` option that is passed to `loaderUtils.interpolateName`. This option is called `localIdentRegExp` in webpack.